### PR TITLE
Fix blog image overflows

### DIFF
--- a/content/posts/2019-03-15/index.md
+++ b/content/posts/2019-03-15/index.md
@@ -20,7 +20,9 @@ Going forward, this bad boy is going to serve as a way for us to let people know
 
 ### 🚨 Attention all GDM members:
 
-![Calling all gamers](johnwick.jpg)
+<p align="center">
+  <img width="100%" src="johnwick.jpg" title="Calling all gamers">
+</p>
 
 The Factory has a leaky ceiling, and Élie needs your help to get sponsorship money to buy out the upstairs tenants who leave their sinks running.
 

--- a/content/posts/2019-03-20/index.md
+++ b/content/posts/2019-03-20/index.md
@@ -16,7 +16,9 @@ tags:
 
 Spring is coming 🌷 and that means that the end (of another academic year) is near. Some of us are (hopefully) graduating and won't be around next year. With half of the exec team gone, this leaves plenty of positions empty along with new positions to be filled on our committee.
 
-![](execs.png)
+<p align="center">
+  <img width="100%" src="execs.png">
+</p>
 
 ## ☀️ Hello new execs!
 

--- a/content/posts/2019-04-11/index.md
+++ b/content/posts/2019-04-11/index.md
@@ -15,23 +15,33 @@ tags:
 
 Don't be fooled by the snow outside; it's definitely April. Although we aren't graced with the usual balmy spring weather, we're still getting to the end of the school year. 2018-2019 was our second year as GameDev McGill, and as the club has grown over the past four semesters, so have all of our members. With the end right around the corner, we wanted to have a public event to highlight the efforts that we've put into our craft!
 
-![Elie in front of empty room](elie.jpeg)
+<p align="center">
+  <img width="100%" src="elie.jpeg" alt="Elie in front of empty room">
+</p>
 
 What ended up happening? Last Tuesday, we booked the EUS Common Room, ordered a bunch of pizza and snacks, and invited everyone to come play the dozen or so games that we had completed over the past school year! It was inspiring to see everyone's creativity come to life, and even cooler to see how their games spanned a whole gamut of genres.
 
 Platformer? Check! Racer? Check! Bullet hell? Check! Horror? Check! Quick-time action theatre stage dressing game with Twitch chat integration? Check! You get the idea...
 
-![Demoing games](play.jpg)
+<p align="center">
+  <img width="100%" src="play.jpg" alt="Demoing Games">
+</p>
 
 Aside from the demos, we also had all the presenters come up in front of the whole audience for a few minutes to give some context on their ideas and how they made them come to life!
 
-![Presenting](presenting.jpg)
+<p align="center">
+  <img width="100%" src="presenting.jpg" alt="Presenting">
+</p>
 
 # 🏆 Winner?
 
 At the end of the night, everyone voted on their favourite game of the night. Without further ado, we'd like to announce that μ-drive by Jonathan Montineri won the popular vote for our first-ever GameDev McGill Showcase! μ-drive is a fast-paced rhythm game inspired by Jonathan's own experiences with Japanese arcade games. Click the image below to see a YouTube video on how it works!
 
-[![Screenshot of μ-drive](mu-drive.jpg)](https://www.youtube.com/watch?feature=player_embedded&v=MCwBT22h5Ms)
+<p align="center">
+  <a href="https://www.youtube.com/watch?feature=player_embedded&v=MCwBT22h5Ms" target="_blank" rel="noopener noreferrer">
+    <img width="100%" src="mu-drive.jpg" alt="Screenshot of μ-drive">
+  </a>
+</p>
 
 If you want to test it out, Jonathan has the game for download on [itch.io](https://jmontineri.itch.io/mu-drive). He also has an active Discord community for the game, where players can discuss the game and share charts for different songs! Check it out [here](https://discord.gg/dzEPPWn).
 

--- a/content/posts/2019-04-17/index.md
+++ b/content/posts/2019-04-17/index.md
@@ -18,7 +18,9 @@ Despite what the weather forecast might say, we are fully in the midst of spring
 
 With that comes all the wonderful spring traditions you're used to: the return of allergies, the flooding of the streets, and the inevitable spring cleaning of your stuff in a moment of clarity motivated by Marie Kondo and finals procrastination.
 
-![](Untitled-4479ba09-92e2-46a8-b416-110200fe9263.png)
+<p align="center">
+  <img width="100%" src="Untitled-4479ba09-92e2-46a8-b416-110200fe9263.png">
+</p>
 
 Montreal spring fashion (where the rock is a pile of dirty snow)
 
@@ -30,7 +32,9 @@ I'd first like to thank the 2018-2019 exec team for all their hard work. They we
 
 (All past execs will be sticking around the discord after their tenure, keep an eye out for the Retired-Executive role 👴👵).
 
-![](Marie_Kondo_Execs-4da3b8e6-a445-4e97-be18-5dc49562b3eb.png)
+<p align="center">
+  <img width="100%" src="Marie_Kondo_Execs-4da3b8e6-a445-4e97-be18-5dc49562b3eb.png">
+</p>
 
 # 🚪 Opening New Doors
 
@@ -100,7 +104,9 @@ A community which could help foster game developers to be the best they can.
 
 While we've had our ups and downs, I am incredibly proud of the community we've built together. I'm constantly impressed and inspired by everyone's creativity and hard work, and I've made some great friends along the way.
 
-![](Untitled-ffb3008c-c4a8-42ca-8be7-3f42ea315054.png)
+<p align="center">
+  <img width="100%" src="Untitled-ffb3008c-c4a8-42ca-8be7-3f42ea315054.png">
+</p>
 
 Fun fact: I had to stall that presentation until the 50 chickens we ordered arrived and were ready to be served 🐓
 

--- a/content/posts/2019-09-22/index.md
+++ b/content/posts/2019-09-22/index.md
@@ -16,7 +16,7 @@ New year, (kinda) new us. As most clubs usually do at the start of each semester
 # 🗣 Tabling
 ## (EUS Involvement Day, SSMU Activities Night, CS Activities Night)
 <p align="center">
-  <img src=https://media0.giphy.com/media/yDPtSqagyx69y/giphy.gif>
+  <img width="100%" src=https://media0.giphy.com/media/yDPtSqagyx69y/giphy.gif>
  </p>
 
  *(jk)*
@@ -26,7 +26,7 @@ We've tabled at three events in these past weeks: EUS' Involvement Day, SSMU's A
 # 🦕 Opening Night
 
 <p align="center">
-  <img src=https://66.media.tumblr.com/5d7d9b3784a28af3c042354b22af2f4f/tumblr_nkjck18Ovw1s9c6nao3_500.gif>
+  <img width="100%" src=https://66.media.tumblr.com/5d7d9b3784a28af3c042354b22af2f4f/tumblr_nkjck18Ovw1s9c6nao3_500.gif>
  </p>
 
 Opening Night! What is it? In essence, at the beginning of a semester, we invite our current members to come visit our club space in the Factory. The event is meant to help them reacquaint themselves with not only the space, but also the resources we have, meet the new execs, and just hang out for a while. It was a small get-together after a long day of classes to say hi and eat some pizza 🍕
@@ -34,14 +34,14 @@ Opening Night! What is it? In essence, at the beginning of a semester, we invite
 Thank you to all our members who came! It was great seeing so many familiar faces again, and even greater to see how everyone reconnected (or connected for the first time). We're excited to see how the rest of the semester'll go 🚀
 
 <p align="center">
-  <img src=IMG_8793-0a375bde-b36e-4c49-8d9d-fcc8c457ec3c.jpg>
+  <img width="100%" src=IMG_8793-0a375bde-b36e-4c49-8d9d-fcc8c457ec3c.jpg>
 </p>
 
   
 # 👋 Info Session
 
 <p align="center">
-  <img src=https://68.media.tumblr.com/706e347a5c670acd6fbb79fbf5a095f6/tumblr_oni1olg4xQ1qgvqxoo2_540.gif>
+  <img width="100%" src=https://68.media.tumblr.com/706e347a5c670acd6fbb79fbf5a095f6/tumblr_oni1olg4xQ1qgvqxoo2_540.gif>
 </p>
 
 
@@ -74,7 +74,7 @@ All in all, its been an eventful past few weeks — it can only go up from here!
 🔸  **Show & Tell**: Another new event, this time for showing off your favorite games. Doesn't have to be one you've made — if you, like me, love Fallout: New Vegas, or Stardew Valley, then you'd come in with a little game trailer or gameplay montage and talk about what makes it great, or talk about your favorite mechanic, character, monster, location, lore — the list is endless. A smaller event, our goal here is to give us all a tighter sense of community by sharing our favorite aspects of our favorite games.
 
 <p align="center">
-  <img src=https://i.pinimg.com/originals/c3/37/f7/c337f7d64998afa12c4eaac01665eafb.gif>
+  <img width="100%" src=https://i.pinimg.com/originals/c3/37/f7/c337f7d64998afa12c4eaac01665eafb.gif>
 </p>
 
 *(One of my many (and I mean many) favorite parts of F:NV was running around and finding all the snow globes. something about finding such a rare collectible in a vast wasteland... it's a pretty great feeling.)*

--- a/content/posts/2019-11-25/index.md
+++ b/content/posts/2019-11-25/index.md
@@ -18,7 +18,7 @@ Three months of go, go, go-ing (vroom vroom 🏎️💨) has resulted into a mul
 ## GameDev Social 2
 
 <p align="center">
-  <img src=https://media.giphy.com/media/xTiTntltYGbF6jBdw4/giphy.gif>
+  <img width="100%" src=https://media.giphy.com/media/xTiTntltYGbF6jBdw4/giphy.gif>
  </p>
 
 A big ol' shout out to the members who made a game, a prototype, presented an idea — there's nothing more inspiring than seeing our members sharing their unique and creative approaches to game dev! Our second Social took place on Nov. 11, with the theme of 🏮 Lantern 🏮 . We got to see a couple of cool ideas come to life — in case you're curious, go check out this month's [itch.io](https://itch.io/jam/game-jam-monthly-october-2019) page!
@@ -32,7 +32,7 @@ We've been asked as to whether we'll be hosting one more Social before the year 
 ## 👶 Extra Life Stream
 
 <p align="center">
-  <img src=https://media.giphy.com/media/26gJA86nNiY4a39Ze/giphy.gif>
+  <img width="100%" src=https://media.giphy.com/media/26gJA86nNiY4a39Ze/giphy.gif>
  </p>
 
 Our **Extra Life Twitch Stream** (where we broadcasted ourselves playing games for charity) was a huge success! We set out to make a 24h fundraising stream for Enfant Soleil, a local hospital charity for children, through Extra Life and surpassed our initial goal of 100$ USD; in total we managed to raise 145.72$ USD. We wish to thank everyone who donated, showed their support — whether by physically streaming, participating remotely as a viewer, or shared the event information — and to our sponsors Ubisoft and EA for helping make this fundraiser possible.
@@ -42,7 +42,7 @@ P.S. [We have a Twitch account](https://www.twitch.tv/gamedevmcgill)! Follow us 
 <p align="center">
   <iframe
       src="https://clips.twitch.tv/embed?clip=PlayfulUnsightlyEelTwitchRPG"
-      width="80%"
+      width="100%"
       height="320px"
       allowfullscreen="true">
   </iframe>
@@ -53,7 +53,7 @@ P.S. [We have a Twitch account](https://www.twitch.tv/gamedevmcgill)! Follow us 
 ## 🎭 Show & Tell
 
 <p align="center">
-  <img src=https://66.media.tumblr.com/de1bd45aa0562e2640bcf1d1f1b83942/tumblr_mqekrwsKsg1rqfhi2o1_400.gif>
+  <img width="100%" src=https://66.media.tumblr.com/de1bd45aa0562e2640bcf1d1f1b83942/tumblr_mqekrwsKsg1rqfhi2o1_400.gif>
 </p>
 
 **Show & Tell** was a new event this year! It's aim was to be an event where we could show our appreciation for games (specifically: what makes them great & why they perform so well as both artistic works and products) in a discussion-based setting. Members shared games that they hold dear and explained how innovative story telling, audio-visual techniques, game design and meticulous planning around player agency propelled these games to hold a cult status as gaming classics and influenced the medium greatly. Some of the games presented were Obra Dinn, Hellblade: Senua's Sacrifice, Skyrim, Fallout 3, Horizon Zero Dawn and Red Alert 2. We are thankful to have such a tight-knit community of devoted and inspired members! ❤️


### PR DESCRIPTION
### List of changes:

- Fixes #7 

### Type of change:

- [x] Bug fix

### How did you do this?

- Add `width="100%"` to all `img` in blog posts
- If the image was previously imported using Markdown, I converted it to use HTML `img` tag for consistency

### Why are you choosing this approach?

### Questions for code reviewers?

### PR Checklist

- [x] Merged `master` branch before testing
- [x] I have linted/formatted my code locally
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)
